### PR TITLE
Untitled

### DIFF
--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -2,12 +2,19 @@
 # Dotfiles index handler kit
 # Sam Briesemeister (c) 2011
 
-import sys, os, pwd, socket, re, fileinput
+import sys, os, pwd, socket, re, fileinput, platform
 
 dotfiles_path = os.getenv('DOTFILES', '%s/.dotfiles' % (os.getenv('HOME')))
 dotfiles_conf = os.getenv('DOTFILES_CONF', '%s/conf/dotfiles.conf' % (dotfiles_path))
 dotfiles_pool = os.getenv('DOTFILES_POOL', '%s/pool/' % (dotfiles_path))
 dotfiles_cache = os.getenv('DOTFILES_CACHE', '%s/.cache' % (dotfiles_pool))
+
+# expandable tags which must be prefixed with `%' in the config
+expandables = { 
+		'system' : platform.system,
+		'dist'   : lambda: platform.dist()[0]
+}
+
 
 def ActiveProfiles(u = None, h = None):
 	u = u or pwd.getpwuid(os.getuid())[0] # current username
@@ -37,7 +44,7 @@ def CollectTags(f, u):
 	tags = []
 	for i in PollTags(f, u):
 		tags.extend(i)
-	return DropExcludeTags(set(tags))
+	return SubstituteExpandableTags(DropExcludeTags(set(tags)))
 
 def DropExcludeTags(t):
 	ex = [ i for i in t if i.startswith('!') ]
@@ -48,6 +55,12 @@ def DropExcludeTags(t):
 		except KeyError, e:
 			continue
 	return t
+
+def SubstituteExpandableTags(t):
+	return [ SanitizeTag(expandables[x[1:]]()) if x.startswith('%') else x for x in t ]
+
+def SanitizeTag(t):
+	return re.sub("[^a-z0-9-]", "", str(t).lower())
 
 def ListDotfiles(base, tags):
 	for t in tags:

--- a/conf/dotfiles.conf.sample
+++ b/conf/dotfiles.conf.sample
@@ -3,19 +3,25 @@
 
 # Tab-separated index, mapping <user@host.network> to various tags
 # Whitespace is interpreted as a field separator, so don't use spaces in your tag names.
-# Tags can be negated with a leading exclamation mark `!'. First field is interpreted as 
-# a regular expression against the current user@host environment.
+#
+# Tags can be negated with a leading exclamation mark `!'. There are expandable tags that
+# change their name depending on the environment they are in. Expandable tags are prefixed with
+# a `%' and currently the following are supported:
+#   %system     The operating system type (linux, etc.)
+#   %dist       Linux distribution (debian, gentoo, etc.)
+# Furthermore, substitutions are always lowercase and stripped-down to alphanumeric characters.
+#
+# First field is interpreted as a regular expression against the current user@host environment.
 #
 #
-# Examples:
+# EXAMPLES
 #
 # // tag every box with `generic'
 # .*@.*                         generic
 #
 # // some servers
-# .*@(xantorini|shad)           server
-# .*@xantorini                  debian debian-server
-# .*@shad                       gentoo
+# .*@(xantorini|shad)           server %dist
+# .*@xantorini                  debian-server
 #
 # // tag all my homeboxes accordingly
 # .*@.*\.home                   home awesome
@@ -35,6 +41,7 @@
 # samba@box.home        -> generic home awesome private
 # samba@box.work        -> generic awesome
 # samba@lamebox.home    -> generic home private
+# samba@xantorini.home  -> generic server debian debian-server home awesome private
 # root@shad             -> generic server gentoo
 
 


### PR DESCRIPTION
I thought having the `conf/dotfiles.conf` file not in the repo might be better to not accidently modify a user's config file when he pulls updates. If you agree, we should also add it to the `.gitignore` which I missed. The documentation should probably be moved into a manpage, eventually.
